### PR TITLE
Add linter for English prose

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,15 @@
+name: Run linter for English prose
+on: [pull_request]
+jobs:
+
+  build:
+    name: Run linter
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - run: |
+        npm install -g write-good 
+        write-good ${GITHUB_WORKSPACE}/README.md --parse


### PR DESCRIPTION
Not sure if his is within scope of the awesome actions demo objectives, but this PR proposes to add a CI example by running the [write-good](https://github.com/btford/write-good) linter against the `README.md` file on the `pull_request` event. Initially it will not pass, but there are only two errors that can easily be fixed:

```
In README.md
=============
tings.yml#L9-L20) with a warm welcome message
                         ^^^^^^^^^^^^
"warm welcome" is a cliche on line 11 at column 200
-------------
orkflows enabled. It can be used as a show case on how Open and Inner Source bes
                         ^^^^^^^
"be used" may be passive voice on line 16 at column 110
```

Replacing them with for example *a welcoming message* and *you use it as a* will pass the build.  